### PR TITLE
Minor cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+
+# Configure stuff
+autom4te.cache
+config.h
+config.log
+config.status
+stamp-h1
+
+# Build stuff
+Makefile
+t/Makefile
+*.o
+
+# Executables
+pssac2

--- a/configure
+++ b/configure
@@ -693,7 +693,6 @@ enable_option_checking
 enable_maintainer_mode
 enable_silent_rules
 with_gmt
-with_netcdf
 enable_dependency_tracking
 '
       ac_precious_vars='build_alias
@@ -1337,7 +1336,6 @@ Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --with-gmt=path         Specify path to GMT
-  --with-netcdf=path      Specify path to NetCDF
 
 Some influential environment variables:
   CC          C compiler command
@@ -2628,15 +2626,6 @@ if test "${with_gmt+set}" = set; then :
 fi
 
 
-# Check whether --with-netcdf was given.
-if test "${with_netcdf+set}" = set; then :
-  withval=$with_netcdf;
-                       LDFLAGS+=" -L${withval}/lib "
-                       CFLAGS+=" -I${withval}/include "
-
-fi
-
-
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
@@ -3733,7 +3722,6 @@ if test "$ac_res" != no; then :
 
 fi
 
-#AC_SEARCH_LIBS(nc_create, netcdf, [], [AC_MSG_ERROR([NetCDF library not found])])
 
 # Extract the first word of "gmt-config", so it can be a program name with args.
 set dummy gmt-config; ac_word=$2

--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@ AS_IF( [ test x"${CFLAGS}" = x ], [ CFLAGS="" ] )
 
 AC_CONFIG_SRCDIR([./pss.c])
 
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([foreign])
 
 AC_ARG_WITH(gmt, [AS_HELP_STRING([--with-gmt=path],[Specify path to GMT])], 
                  [

--- a/configure.ac
+++ b/configure.ac
@@ -18,16 +18,9 @@ AC_ARG_WITH(gmt, [AS_HELP_STRING([--with-gmt=path],[Specify path to GMT])],
                    [ LDFLAGS+=" -L${withval}/lib "] 
                    [ CFLAGS+=" -I${withval}/include  " ]
                  ], [])
-AC_ARG_WITH(netcdf, [AS_HELP_STRING([--with-netcdf=path],
-                    [Specify path to NetCDF])], 
-                    [ 
-                      [ LDFLAGS+=" -L${withval}/lib " ]
-                      [ CFLAGS+=" -I${withval}/include " ] 
-                    ], [])
 
 AC_PROG_CC
 AC_SEARCH_LIBS(sin, m)
-#AC_SEARCH_LIBS(nc_create, netcdf, [], [AC_MSG_ERROR([NetCDF library not found])])
 
 AC_CHECK_PROG([GMTCONFIG], [gmt-config], [gmt-config])
 test -z "$GMTCONFIG" && AC_MSG_ERROR([Missing GMT5 nstallation.])

--- a/pss.c
+++ b/pss.c
@@ -1,4 +1,5 @@
 
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Just a couple of minor bits to cleanup the build and git settings.
- automake complains about missing files
- NetCDF option is not used for anything
- `git status` shows many untracked files because they are not ignored
- `asprintf` causes a compiler warning since it's a GNU extension
